### PR TITLE
Fix pygame backend; use pygame_sdl2 when possible

### DIFF
--- a/Box2D/Box2D_math.i
+++ b/Box2D/Box2D_math.i
@@ -305,12 +305,15 @@ public:
         # Read-only
         inverse = property(__GetInverse, None)
         angle = property(__GetAngle, __SetAngle)
-        ex = property(lambda self: self.col1, lambda self, v: setattr(self, 'col1', v))
-        ey = property(lambda self: self.col2, lambda self, v: setattr(self, 'col2', v))
+        ex = property(lambda self: self.col1,
+                      lambda self, v: setattr(self, 'col1', v))
+        ey = property(lambda self: self.col2,
+                      lambda self, v: setattr(self, 'col2', v))
         set = __SetAngle
     %}
     b2Vec2 __mul__(b2Vec2* v) {
-        return b2Vec2($self->ex.x * v->x + $self->ey.x * v->y, $self->ex.y * v->x + $self->ey.y * v->y);
+        return b2Vec2($self->ex.x * v->x + $self->ey.x * v->y,
+                      $self->ex.y * v->x + $self->ey.y * v->y);
     }
     b2Mat22 __mul__(b2Mat22* m) {
         return b2Mat22(b2Mul(*($self), m->ex), b2Mul(*($self), m->ey));
@@ -395,23 +398,23 @@ public:
 /**** Transform ****/
 %extend b2Transform {
 public:
+    b2Rot __get_rotation_matrix() {
+        return $self->q;
+    }
+
     %pythoncode %{
-        def __GetAngle(self):
+        def __get_angle(self):
             return self.q.angle
-        def __SetAngle(self, angle):
+        def __set_angle(self, angle):
             self.q.angle = angle
 
-        def __GetR(self):
-            R = b2Mat22()
-            R.angle = self.q.angle
-            return R
+        def __set_rotation_matrix(self, rot_matrix):
+            self.q.angle = rot_matrix.angle
 
-        def __SetR(self, R):
-            self.q.angle = R.angle
-
-        angle = property(__GetAngle, __SetAngle) 
-        R = property(__GetR, __SetR)
+        angle = property(__get_angle, __set_angle) 
+        R = property(__get_rotation_matrix, __set_rotation_matrix)
     %}
+
     b2Vec2 __mul__(b2Vec2& v) {
         float32 x = ($self->q.c * v.x - $self->q.s * v.y) + $self->p.x;
         float32 y = ($self->q.s * v.x + $self->q.c * v.y) + $self->p.y;

--- a/examples/apply_force.py
+++ b/examples/apply_force.py
@@ -47,11 +47,11 @@ class ApplyForce (Framework):
         #  TODO: make note of transform.R.set() -> transform.angle =
         xf1 = b2Transform()
         xf1.angle = 0.3524 * b2_pi
-        xf1.position = b2Mul(xf1.R, (1.0, 0.0))
+        xf1.position = xf1.R * (1.0, 0.0)
 
         xf2 = b2Transform()
         xf2.angle = -0.3524 * b2_pi
-        xf2.position = b2Mul(xf2.R, (-1.0, 0.0))
+        xf2.position = xf2.R * (-1.0, 0.0)
         self.body = self.world.CreateDynamicBody(
             position=(0, 2),
             angle=b2_pi,

--- a/examples/backends/opencv_framework.py
+++ b/examples/backends/opencv_framework.py
@@ -99,8 +99,8 @@ class OpencvDraw(framework.b2DrawExtended):
         Draw the transform xf on the screen
         """
         p1 = xf.position
-        p2 = self.to_screen(p1 + self.axisScale * xf.R.col1)
-        p3 = self.to_screen(p1 + self.axisScale * xf.R.col2)
+        p2 = self.to_screen(p1 + self.axisScale * xf.R.x_axis)
+        p3 = self.to_screen(p1 + self.axisScale * xf.R.y_axis)
         p1 = self.to_screen(p1)
         cv2.line(self.surface, cvcoord(p1), cvcoord(p2), (0, 0, 255), 1)
         cv2.line(self.surface, cvcoord(p1), cvcoord(p3), (0, 255, 0), 1)

--- a/examples/backends/pygame_framework.py
+++ b/examples/backends/pygame_framework.py
@@ -36,6 +36,20 @@ Mouse:
 """
 
 from __future__ import (print_function, absolute_import, division)
+import sys
+import warnings
+
+try:
+    import pygame_sdl2
+except ImportError:
+    if sys.platform in ('darwin', ):
+        warnings.warn('OSX has major issues with pygame/SDL 1.2 when used '
+                      'inside a virtualenv. If this affects you, try '
+                      'installing the updated pygame_sdl2 library.')
+else:
+    # pygame_sdl2 is backward-compatible with pygame:
+    pygame_sdl2.import_as_pygame()
+
 import pygame
 from pygame.locals import (QUIT, KEYDOWN, KEYUP, MOUSEBUTTONDOWN,
                            MOUSEBUTTONUP, MOUSEMOTION, KMOD_LSHIFT)
@@ -108,10 +122,9 @@ class PygameDraw(b2DrawExtended):
         Draw the transform xf on the screen
         """
         p1 = xf.position
-        p2 = self.to_screen(p1 + self.axisScale * xf.R.col1)
-        p3 = self.to_screen(p1 + self.axisScale * xf.R.col2)
+        p2 = self.to_screen(p1 + self.axisScale * xf.R.x_axis)
+        p3 = self.to_screen(p1 + self.axisScale * xf.R.y_axis)
         p1 = self.to_screen(p1)
-
         pygame.draw.aaline(self.surface, (255, 0, 0), p1, p2)
         pygame.draw.aaline(self.surface, (0, 255, 0), p1, p3)
 

--- a/examples/backends/pyglet_framework.py
+++ b/examples/backends/pyglet_framework.py
@@ -323,8 +323,8 @@ class PygletDraw(b2Draw):
         """
         p1 = xf.position
         k_axisScale = 0.4
-        p2 = p1 + k_axisScale * xf.R.col1
-        p3 = p1 + k_axisScale * xf.R.col2
+        p2 = p1 + k_axisScale * xf.R.x_axis
+        p3 = p1 + k_axisScale * xf.R.y_axis
 
         self.batch.add(3, gl.GL_LINES, None,
                        ('v2f', (p1[0], p1[1], p2[0], p2[

--- a/examples/backends/pyqt4_framework.py
+++ b/examples/backends/pyqt4_framework.py
@@ -142,8 +142,8 @@ class Pyqt4Draw(object):
         Draw the transform xf on the screen
         """
         p1 = xf.position
-        p2 = p1 + self.axisScale * xf.R.col1
-        p3 = p1 + self.axisScale * xf.R.col2
+        p2 = p1 + self.axisScale * xf.R.x_axis
+        p3 = p1 + self.axisScale * xf.R.y_axis
 
         line1 = self.scene.addLine(p1[0], p1[1], p2[0], p2[1],
                                    pen=QtGui.QPen(QColor(255, 0, 0)))
@@ -217,7 +217,7 @@ class Pyqt4Draw(object):
     def DrawCircleShape(self, shape, transform, color, temporary=False):
         center = b2Mul(transform, shape.pos)
         radius = shape.radius
-        axis = transform.R.col1
+        axis = transform.R.x_axis
 
         border_color = color.bytes + [255]
         inside_color = (color / 2).bytes + [127]
@@ -280,7 +280,7 @@ class Pyqt4Draw(object):
                     center = b2Mul(transform, shape.pos)
                     items[0].setPos(*center)
                     line = items[1]
-                    axis = transform.R.col1
+                    axis = transform.R.x_axis
                     line.setLine(center[0], center[1],
                                  (center[0] - radius * axis[0]),
                                  (center[1] - radius * axis[1]))

--- a/examples/framework.py
+++ b/examples/framework.py
@@ -461,7 +461,7 @@ class FrameworkBase(b2ContactListener):
         self.points.extend([dict(fixtureA=contact.fixtureA,
                                  fixtureB=contact.fixtureB,
                                  position=worldManifold.points[i],
-                                 normal=worldManifold.normal,
+                                 normal=worldManifold.normal.copy(),
                                  state=state2[i],
                                  )
                             for i, point in enumerate(state2)])

--- a/examples/pgu/gui/surface.py
+++ b/examples/pgu/gui/surface.py
@@ -67,7 +67,8 @@ class ProxySurface:
     def get_abs_offset(): return self.rect[:2]
     def get_abs_parent(): return self.mysubsurface.get_abs_parent()
     def set_clip(self, rect=None): 
-        if rect == None: self.mysubsurface.set_clip()
+        if rect == None: 
+            self.mysubsurface.set_clip(self.mysubsurface.get_rect())
         else: 
             rect = [rect[0] + self.offset[0] + self.x, rect[1] + self.offset[0] + self.y, rect[2], rect[3]]
             self.mysubsurface.set_clip(rect)
@@ -107,7 +108,8 @@ class xProxySurface:
     def get_abs_offset(): return self.rect[:2]
     def get_abs_parent(): return self.mysubsurface.get_abs_parent()
     def set_clip(self, rect=None): 
-        if rect == None: self.mysubsurface.set_clip()
+        if rect == None: 
+            self.mysubsurface.set_clip(self.mysubsurface.get_rect())
         else: 
             rect = [rect[0] + self.offset[0] + self.x, rect[1] + self.offset[0] + self.y, rect[2], rect[3]]
             self.mysubsurface.set_clip(rect)

--- a/examples/pgu/gui/theme.py
+++ b/examples/pgu/gui/theme.py
@@ -459,8 +459,8 @@ class Theme:
         dest.y = yy-hh*2
         s.set_clip(pygame.Rect(xx-ww,y+hh,xx,h-hh*2))
         s.blit(box,dest,src)
-        
-        s.set_clip()
+       	
+        s.set_clip(s.get_rect())
         src.x,src.y,dest.x,dest.y = 0,0,x,y
         s.blit(box,dest,src)
         

--- a/library/Box2D/Box2D.py
+++ b/library/Box2D/Box2D.py
@@ -533,13 +533,17 @@ def b2Distance(shapeA=None, idxA=0, shapeB=None, idxB=0, transformA=None, transf
     Compute the closest points between two shapes.
 
     Can be called one of two ways:
-    + b2Distance(b2DistanceInput) # utilizes the b2DistanceInput structure, where you define your own proxies
+    + b2Distance(b2DistanceInput)
+    This uses the b2DistanceInput structure, where you define your own
+    distance proxies
 
-    Or utilizing kwargs:
-    + b2Distance(shapeA=.., idxA=0, shapeB=.., idxB=0, transformA=.., transformB=.., useRadii=True)
+    Or more conveniently using kwargs:
+    + b2Distance(shapeA=.., idxA=0, shapeB=.., idxB=0, transformA=..,
+                 transformB=.., useRadii=True)
 
-    Returns a tuple in the form:
-     ((pointAx, pointAy), (pointBx, pointBy), distance, iterations)
+    Returns a namedtuple in the form:
+        b2DistanceResult(pointA=(ax, ay), pointB=(bx, by), distance,
+                         iterations)
     """
     if isinstance(shapeA, b2DistanceInput):
         out = _b2Distance(shapeA)
@@ -1358,8 +1362,10 @@ class b2Mat22(object):
             # Read-only
     inverse = property(__GetInverse, None)
     angle = property(__GetAngle, __SetAngle)
-    ex = property(lambda self: self.col1, lambda self, v: setattr(self, 'col1', v))
-    ey = property(lambda self: self.col2, lambda self, v: setattr(self, 'col2', v))
+    ex = property(lambda self: self.col1,
+                  lambda self, v: setattr(self, 'col1', v))
+    ey = property(lambda self: self.col2,
+                  lambda self, v: setattr(self, 'col2', v))
     set = __SetAngle
 
 
@@ -1622,21 +1628,21 @@ class b2Transform(object):
         return _format_repr(self) 
 
 
-    def __GetAngle(self):
+    def __get_rotation_matrix(self):
+        """__get_rotation_matrix(b2Transform self) -> b2Rot"""
+        return _Box2D.b2Transform___get_rotation_matrix(self)
+
+
+    def __get_angle(self):
         return self.q.angle
-    def __SetAngle(self, angle):
+    def __set_angle(self, angle):
         self.q.angle = angle
 
-    def __GetR(self):
-        R = b2Mat22()
-        R.angle = self.q.angle
-        return R
+    def __set_rotation_matrix(self, rot_matrix):
+        self.q.angle = rot_matrix.angle
 
-    def __SetR(self, R):
-        self.q.angle = R.angle
-
-    angle = property(__GetAngle, __SetAngle) 
-    R = property(__GetR, __SetR)
+    angle = property(__get_angle, __set_angle) 
+    R = property(__get_rotation_matrix, __set_rotation_matrix)
 
 
     def __mul__(self, v):
@@ -1647,6 +1653,7 @@ class b2Transform(object):
 b2Transform.SetIdentity = new_instancemethod(_Box2D.b2Transform_SetIdentity, None, b2Transform)
 b2Transform.Set = new_instancemethod(_Box2D.b2Transform_Set, None, b2Transform)
 b2Transform.__hash__ = new_instancemethod(_Box2D.b2Transform___hash__, None, b2Transform)
+b2Transform.__get_rotation_matrix = new_instancemethod(_Box2D.b2Transform___get_rotation_matrix, None, b2Transform)
 b2Transform.__mul__ = new_instancemethod(_Box2D.b2Transform___mul__, None, b2Transform)
 b2Transform_swigregister = _Box2D.b2Transform_swigregister
 b2Transform_swigregister(b2Transform)

--- a/library/Box2D/__init__.py
+++ b/library/Box2D/__init__.py
@@ -19,8 +19,8 @@
 # 
 from .Box2D import *
 __author__ = '$Date$'
-__version__ = '2.3b0'
-__version_info__ = (2,3,0)
+__version__ = '2.3.1'
+__version_info__ = (2,3,1)
 __revision__ = '$Revision$'
 __license__ = 'zlib'
 __date__ = '$Date$'

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ box2d_version  = '2.3'
 release_number = 1
 
 # create the version string
-version_str = "%sb%s" % (box2d_version, release_number)
+version_str = "%s.%s" % (box2d_version, release_number)
 
 # setup some paths and names
 library_base='library' # the directory where the egg base will be for setuptools develop command


### PR DESCRIPTION
Using pygame_sdl2 when possible due to some issues experienced with virtualenv/conda on OSX.
Updated PGU to be compatible with it.

Also, b2Transform.R now properly returns a b2Rot instead of a b2Mat22.

For reference: [pygame_sdl2 repo](https://github.com/renpy/pygame_sdl2) (and my [pygame_sdl2 conda builds](https://anaconda.org/kne/pygame_sdl2))