### PR TITLE
Added Python 3.6 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   # - "pypy"  # swig doesn't seem to work :(
 
 dist: trusty


### PR DESCRIPTION
pybox2d should be able to work with python 3.6 as there were no breaking changes.