### PR TITLE
replaced deprecated method in test_joints.py

### DIFF
--- a/tests/test_joints.py
+++ b/tests/test_joints.py
@@ -97,7 +97,7 @@ class testJoints (unittest.TestCase):
         else:
             b = getattr(joint, prop)
 
-        self.assertEquals(a, b, "Property not equal from definition to joint: %s (dfn %s != joint %s)" % (prop, a, b) )
+        self.assertEqual(a, b, "Property not equal from definition to joint: %s (dfn %s != joint %s)" % (prop, a, b))
 
     # ---- revolute joint ----
     def revolute_definition(self, body1, body2, anchor):


### PR DESCRIPTION
While running this test a deprecatedWarning appeared so, I just change the method as the test module suggested.