### PR TITLE
fix: fpermissive error on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ if use_kwargs:
 # isn't windows, g++ will be used; -Wno-unused then would suppress some annoying warnings
 # about the Box2D source.
 if sys.platform in ('win32', 'win64'):
-    extra_args=['-I.']
+    extra_args=['-I.', '-fpermissive']
 else:
     extra_args=['-I.', '-Wno-unused']
 


### PR DESCRIPTION
This fixes the issue: https://github.com/pybox2d/pybox2d/issues/111

Currently this package is not installable on Windows 10/Anaconda 4.7+. The reason is that Anaconda is now using GCC 5.3 and this has -fno-permissive on by default. This means any casts in C++ code that loses precision is considered as error. To fix this, -fpermissive is added for Windows compilation. The real fix would be needed in Box2D C++ code that uses modern casts. This PR will at least unblock users until then.