### PR TITLE
Run build_ext step before build_py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,12 @@ __license__='zlib'
 
 import setuptools
 from setuptools import (setup, Extension)
+from setuptools.command.build_py import build_py
+
+class build_py_after_build_ext(build_py):
+    def run(self):
+        self.run_command('build_ext')
+        return super().run()
 
 # release version number
 box2d_version  = '2.3'
@@ -138,6 +144,7 @@ setup_dict = dict(
                         },
     ext_modules      = [ pybox2d_extension ],
     include_package_data=True,
+    cmdclass={"build_py": build_py_after_build_ext},
     )
 
 # run the actual setup from distutils


### PR DESCRIPTION
Right now the build_py step runs before build_ext which causes the python files generates by swig to not be included in the package.  Any build from a fresh checkout will fail.  This PR changed the build_py step to first run build_ext.