### PR TITLE
Fix #119, DestroyBody may trigger EndContact.

### DIFF
--- a/Box2D/Box2D_userdata.i
+++ b/Box2D/Box2D_userdata.i
@@ -43,21 +43,24 @@ public:
     }
 
     void DestroyBody(b2Body* body) {
-        Py_XDECREF((PyObject*)body->GetUserData());
+        void *userData = body->GetUserData();
         self->DestroyBody(body);
+        Py_XDECREF((PyObject*)userData);
     }
 
     void DestroyJoint(b2Joint* joint) {
-        Py_XDECREF((PyObject*)joint->GetUserData());
+        void *userData = joint->GetUserData();
         self->DestroyJoint(joint);
+        Py_XDECREF((PyObject*)userData);
     }
 }
 
 %extend b2Body {
 public:        
     void DestroyFixture(b2Fixture* fixture) {
-        Py_XDECREF((PyObject*)fixture->GetUserData());
+        void *userData = fixture->GetUserData();
         self->DestroyFixture(fixture);
+        Py_XDECREF((PyObject*)userData);
     }
     b2Fixture* __CreateFixture(b2FixtureDef* defn) {
         b2Fixture* ret;


### PR DESCRIPTION
DestroyBody may trigger EndContact.
Py_XDECREF may cause userData to be released before DestroyBody.

Here we put the Py_XDECREF after DestroyBody. So in EndContact callback the userData should be valid.

It's still not 100% safe. Bad thing will happen if user code try to change userData in EndContact callback called from DestroyBody.
It should be safer than before though.