### PR TITLE
Correct DrawCircle docstring

### DIFF
--- a/library/Box2D/examples/backends/pygame_framework.py
+++ b/library/Box2D/examples/backends/pygame_framework.py
@@ -119,8 +119,7 @@ class PygameDraw(b2DrawExtended):
 
     def DrawCircle(self, center, radius, color, drawwidth=1):
         """
-        Draw a wireframe circle given the center, radius, axis of orientation
-        and color.
+        Draw a wireframe circle given the center, radius and color.
         """
         radius *= self.zoom
         if radius < 1:


### PR DESCRIPTION
Remove reference to axis of orientation as it is not used by DrawCircle method