### PR TITLE
Declare build dependencies in pyproject.toml to comply with with PEP-518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "swig"]


### PR DESCRIPTION
Adds `pyproject.toml`.

I installed `swig` by pip in virtual environment. Then I got `No module named 'swig'` error when I tried to install `box2d`. This PR fixes that error.